### PR TITLE
Add minimal agent demo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and fill in your API key and model
+OPENAI_API_KEY=YOUR_KEY_HERE
+MODEL=gpt-4o-mini

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+.env
+runs/
+out/
+.sandbox/
+__pycache__/

--- a/agent.config.yaml
+++ b/agent.config.yaml
@@ -1,0 +1,14 @@
+model: ${MODEL}
+temperature: 0.2
+seed: 42
+timeout_s: 120
+sandbox_dir: ".sandbox"
+out_dir: "out"
+persist_logs: true
+redact_secrets: true
+redact_keys:
+  - OPENAI_API_KEY
+  - API_KEY
+  - SECRET
+tools:
+  - fs

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,1 @@
+# Transparent Agent package

--- a/agent/__main__.py
+++ b/agent/__main__.py
@@ -1,0 +1,82 @@
+import argparse
+import os
+from datetime import datetime
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+def run(goal: str, context_paths: str, tools: str, report_path: str) -> None:
+    """Execute a minimal run and write a markdown report."""
+    load_dotenv()
+    context_texts = []
+    if context_paths:
+        for p in context_paths.split(","):
+            p = p.strip()
+            if not p:
+                continue
+            try:
+                with open(p, "r", encoding="utf-8") as f:
+                    context_texts.append(f.read())
+            except FileNotFoundError:
+                context_texts.append(f"[missing context file: {p}]")
+    context_content = "\n\n".join(context_texts)
+
+    model = os.getenv("MODEL", "gpt-4o-mini")
+    api_key = os.getenv("OPENAI_API_KEY")
+    if api_key:
+        try:
+            from openai import OpenAI
+
+            client = OpenAI(api_key=api_key)
+            messages = [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": f"Goal: {goal}\nContext:\n{context_content}"},
+            ]
+            completion = client.chat.completions.create(
+                model=model,
+                messages=messages,
+            )
+            result = completion.choices[0].message.content
+        except Exception as e:  # pragma: no cover - best effort
+            result = f"Model call failed: {e}"
+    else:
+        result = "OPENAI_API_KEY not set. Skipping model call."
+
+    report = f"""# Run Report - {datetime.utcnow().isoformat()}Z
+
+## Inputs
+- goal: {goal}
+- context files: {context_paths}
+- model: {model}
+- tools: {tools}
+
+## Output
+{result}
+"""
+
+    report_file = Path(report_path)
+    report_file.parent.mkdir(parents=True, exist_ok=True)
+    report_file.write_text(report, encoding="utf-8")
+    print(f"Report written to {report_file}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="agent")
+    subparsers = parser.add_subparsers(dest="command")
+
+    run_parser = subparsers.add_parser("run", help="run a goal")
+    run_parser.add_argument("--goal", required=True)
+    run_parser.add_argument("--context", default="")
+    run_parser.add_argument("--tools", default="")
+    run_parser.add_argument("--report", default="out/report.md")
+
+    args = parser.parse_args()
+    if args.command == "run":
+        run(args.goal, args.context, args.tools, args.report)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sample_context.md
+++ b/examples/sample_context.md
@@ -1,0 +1,2 @@
+This is a sample context file.
+It provides additional information for the agent.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openai>=1.0.0
+python-dotenv>=1.0.0


### PR DESCRIPTION
## Summary
- add simple CLI entrypoint to run an agent task and write a markdown report
- include default configuration, sample context, and env template

## Testing
- `pip install -r requirements.txt`
- `python -m agent run --goal "Say hello" --context "examples/sample_context.md" --tools "fs" --report out/test_report.md`


------
https://chatgpt.com/codex/tasks/task_e_689a7bb6fe188322a532086de1169a29